### PR TITLE
chore: add CODEOWNERS (SDKs - Maintainers)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Default owners for everything in this repo.
+# The SDKs - Maintainers team reviews and merges all changes.
+# https://docs.github.com/articles/about-code-owners
+* @blueinkhq/sdks-maintainers


### PR DESCRIPTION
Adds a `.github/CODEOWNERS` file assigning the **SDKs - Maintainers** team (`@blueinkhq/sdks-maintainers`) as the default owner of the whole repo.

This routes review requests to the team automatically. Branch-rule enforcement for the public repos will be handled in a follow-up pass.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01KY6579WF36E0GR4YD5VWTBTD&panel=chat)